### PR TITLE
Fix PHP Notice on post save when any of the supported sidebars have been unregistered

### DIFF
--- a/includes/inpost.php
+++ b/includes/inpost.php
@@ -80,8 +80,8 @@ function ss_inpost_metabox_save( $post_id, $post ) {
 		return $post->ID;
 
 	$_sidebars = array(
-		'_ss_sidebar'     => $_POST['_ss_sidebar'],
-		'_ss_sidebar_alt' => $_POST['_ss_sidebar_alt'],
+		'_ss_sidebar'     => isset( $_POST['_ss_sidebar'] ) ? $_POST['_ss_sidebar'] : false,
+		'_ss_sidebar_alt' => isset( $_POST['_ss_sidebar_alt'] ) ? $_POST['_ss_sidebar_alt'] : false,
 	);
 
 	//* store the custom fields


### PR DESCRIPTION
If a theme or plugin has unregistered one of the supported sidebars, e.g. `unregister_sidebar( 'sidebar-alt' );` (as many custom themes do), there's a PHP Notice on every post save:

```PHP Notice:  Undefined index: _ss_sidebar_alt in /Sites/www/wp-content/plugins/genesis-simple-sidebars/includes/inpost.php on line 84```

This checks if the $_POST values are set first before assigning them to the array and fixes the notice.