### PR TITLE
Allow custom sidebars for Header Right widget area

### DIFF
--- a/includes/inpost.php
+++ b/includes/inpost.php
@@ -58,6 +58,22 @@ function ss_inpost_metabox() {
 
 <?php
 	}
+	if( isset( $wp_registered_sidebars['header-right'] ) ) {
+?>
+	<p>
+		<label class="howto" for="_ss_sidebar_header_right"><span><?php echo esc_attr( $wp_registered_sidebars['header-right']['name'] ); ?><span></label>
+		<select name="_ss_sidebar_header_right" id="_ss_sidebar_header_right" style="width: 99%">
+			<option value=""><?php _e( 'Default', 'ss' ); ?></option>
+			<?php
+			foreach ( (array) $_sidebars as $id => $info ) {
+				printf( '<option value="%s" %s>%s</option>', esc_html( $id ), selected( $id, genesis_get_custom_field( '_ss_sidebar_header_right' ), false ), esc_html( $info['name'] ) );
+			}
+			?>
+		</select>
+	</p>
+
+<?php
+	}
 }
 
 add_action( 'save_post', 'ss_inpost_metabox_save', 1, 2 );
@@ -82,6 +98,7 @@ function ss_inpost_metabox_save( $post_id, $post ) {
 	$_sidebars = array(
 		'_ss_sidebar'     => $_POST['_ss_sidebar'],
 		'_ss_sidebar_alt' => $_POST['_ss_sidebar_alt'],
+		'_ss_sidebar_header_right' => $_POST['_ss_sidebar_header_right'],
 	);
 
 	//* store the custom fields

--- a/includes/term.php
+++ b/includes/term.php
@@ -20,7 +20,7 @@ function ss_term_edit_init() {
 function ss_term_sidebar($tag, $taxonomy) {
 
 	//* Merge Defaults to prevent notices
-	$tag->meta = wp_parse_args( $tag->meta, array( '_ss_sidebar' => '', '_ss_sidebar_alt' => '' ) );
+	$tag->meta = wp_parse_args( $tag->meta, array( '_ss_sidebar' => '', '_ss_sidebar_alt' => '', '_ss_sidebar_header_right' => '' ) );
 
 	//* Pull custom sidebars
 	$_sidebars = stripslashes_deep( get_option( SS_SETTINGS_FIELD ) );
@@ -55,6 +55,26 @@ function ss_term_sidebar($tag, $taxonomy) {
 				<?php
 				foreach ( (array) $_sidebars as $id => $info ) {
 					printf( '<option value="%s" %s>%s</option>', esc_html( $id ), selected( $id, $tag->meta['_ss_sidebar_alt'] , false), esc_html( $info['name'] ) );
+				}
+				?>
+			</select>
+		</td>
+	</tr>
+<?php
+	}
+?>
+<?php
+	//* don't show the option if header right is not registered
+	if ( is_active_sidebar( 'header-right' ) ) {
+?>
+	<tr class="form-field">
+		<th scope="row" valign="top"><label for="genesis-meta[_ss_sidebar_header_right]"><?php _e( 'Header Right Sidebar', 'ss' ); ?></label></th>
+		<td>
+			<select name="genesis-meta[_ss_sidebar_header_right]" id="genesis-meta[_ss_sidebar_header_right]" style="padding-right: 10px;">
+				<option value=""><?php _e( 'Default', 'ss' ); ?></option>
+				<?php
+				foreach ( (array) $_sidebars as $id => $info ) {
+					printf( '<option value="%s" %s>%s</option>', esc_html( $id ), selected( $id, $tag->meta['_ss_sidebar_header_right'] , false), esc_html( $info['name'] ) );
 				}
 				?>
 			</select>

--- a/plugin.php
+++ b/plugin.php
@@ -124,8 +124,10 @@ function ss_sidebars_init() {
 
 	remove_action( 'genesis_sidebar', 'genesis_do_sidebar' );
 	remove_action( 'genesis_sidebar_alt', 'genesis_do_sidebar_alt' );
+	remove_action( 'genesis_header', 'genesis_do_header' );
 	add_action( 'genesis_sidebar', 'ss_do_sidebar' );
 	add_action( 'genesis_sidebar_alt', 'ss_do_sidebar_alt' );
+	add_action( 'genesis_header', 'ss_do_header' );
 
 }
 
@@ -154,6 +156,51 @@ function ss_do_sidebar_alt() {
 
 	if ( ! ss_do_one_sidebar( '_ss_sidebar_alt' ) )
 		genesis_do_sidebar_alt();
+
+}
+
+/**
+ * Display header right.
+ *
+ * Display custom sidebar if one exists, else display default header right sidebar.
+ *
+ * @since 0.9.0
+ */
+function ss_do_header() {
+
+	global $wp_registered_sidebars;
+
+	genesis_markup( array(
+		'html5'   => '<div %s>',
+		'xhtml'   => '<div id="title-area">',
+		'context' => 'title-area',
+	) );
+	do_action( 'genesis_site_title' );
+	do_action( 'genesis_site_description' );
+	echo '</div>';
+
+	if ( ( isset( $wp_registered_sidebars['header-right'] ) && is_active_sidebar( 'header-right' ) ) || has_action( 'genesis_header_right' ) ) {
+		genesis_markup( array(
+			'html5'   => '<aside %s>',
+			'xhtml'   => '<div class="widget-area header-widget-area">',
+			'context' => 'header-widget-area',
+		) );
+
+			do_action( 'genesis_header_right' );
+			add_filter( 'wp_nav_menu_args', 'genesis_header_menu_args' );
+			add_filter( 'wp_nav_menu', 'genesis_header_menu_wrap' );
+
+			if ( ! ss_do_one_sidebar( '_ss_sidebar_header_right' ) )
+				dynamic_sidebar( 'header-right' );
+
+			remove_filter( 'wp_nav_menu_args', 'genesis_header_menu_args' );
+			remove_filter( 'wp_nav_menu', 'genesis_header_menu_wrap' );
+
+		genesis_markup( array(
+			'html5' => '</aside>',
+			'xhtml' => '</div>',
+		) );
+	}
 
 }
 


### PR DESCRIPTION
Added functions to override `genesis_go_header` and display custom sidebar in Header Right widget area, defaulting back to Header Right (if active) if no widgets are present in custom sidebar.

I didn't re-create any .pot files. I only added one translatable string in `includes/term.php` line 71, and it can be removed and changed to `<?php echo esc_attr( $wp_registered_sidebars['header-right']['name'] ); ?>` if appropriate. I wasn't sure how you typically generate them (via the WordPress.org plugin repo admin page, the WordPress i18n tools, etc), but I can re-generate it if needed.
