### PR TITLE
fix:  Added wp_kses() to latest version notice

### DIFF
--- a/includes/class-genesis-simple-sidebars.php
+++ b/includes/class-genesis-simple-sidebars.php
@@ -93,18 +93,20 @@ class Genesis_Simple_Sidebars {
 	 * @since 2.1.0
 	 */
 	public function requirements_notice() {
-
-		if ( ! defined( 'PARENT_THEME_VERSION' ) || ! version_compare( PARENT_THEME_VERSION, $this->min_genesis_version, '>=' ) ) {
-
-			$action = defined( 'PARENT_THEME_VERSION' ) ? __( 'upgrade to', 'genesis-simple-sidebars' ) : __( 'install and activate', 'genesis-simple-sidebars' );
-
-			// translators: %1$s is WordPress minimum version, %2$s is Genesis minimum version, %3$s is action and %4$s is link.
-			$message = sprintf( __( 'Genesis Simple Sidebars requires WordPress %1$s and Genesis %2$s, or greater. Please %3$s the latest version of <a href="%4$s" target="_blank">Genesis</a> to use this plugin.', 'genesis-simple-sidebars' ), $this->min_wp_version, $this->min_genesis_version, $action, 'http://my.studiopress.com/?download_id=91046d629e74d525b3f2978e404e7ffa' );
-			echo '<div class="notice notice-warning"><p>' . esc_html( $message ) . '</p></div>';
-
-		}
-
-	}
+	        if ( ! defined( 'PARENT_THEME_VERSION' ) || ! version_compare( PARENT_THEME_VERSION, $this->min_genesis_version, '>=' ) ) {
+	            $allowed_HTML = array(
+	                'a' => array(
+	                'href' => array(),
+	                'title' => array()
+	                )
+	            );
+	            $action = defined( 'PARENT_THEME_VERSION' ) ? __( 'upgrade to', 'genesis-simple-sidebars' ) : __( 'install and activate', 'genesis-simple-sidebars' );
+	            // translators: %1$s is WordPress minimum version, %2$s is Genesis minimum version, %3$s is action and %4$s is link.
+	            $message = sprintf( __( 'Genesis Simple Sidebars requires WordPress %1$s and Genesis %2$s, or greater. Please %3$s the latest version of <a href="%4$s" target="_blank">Genesis</a> to use this plugin.', 'genesis-simple-sidebars' ), $this->min_wp_version, $this->min_genesis_version, $action, 'http://my.studiopress.com/?download_id=91046d629e74d525b3f2978e404e7ffa' );
+	            echo '<div class="notice notice-warning"><p>' . wp_kses( $message, $allowed_HTML ) . '</p></div>';
+	            
+	        }
+	    }
 
 	/**
 	 * Load the plugin textdomain, for translation.


### PR DESCRIPTION
**Summary of change:**
In the version 2.2.1, When you display the notice to the users for the minimum genesis theme version, the HTML gets printed in the notice as it is because you have used the esc_html for escaping the $message variable.
The notice is displayed in the admin area like this:
https://share.getcloudapp.com/yAuvb6Pn
I have used the Wp_kses() function for escaping it allows only allowed HTML.
Now the notice is displayed correctly in the admin area.
Please see here:https://share.getcloudapp.com/2NuByEKe


**How to test:**
You can check this by rolling back to previous versions of genesis. It will help you to display the notice.
