### PR TITLE
[GF-3978] fix: stop corrupt sidebar data from causing errors

### DIFF
--- a/includes/class-genesis-simple-sidebars-core.php
+++ b/includes/class-genesis-simple-sidebars-core.php
@@ -172,9 +172,12 @@ class Genesis_Simple_Sidebars_Core {
 		 * corrupted sidebar data from throwing errors, as seen in:
 		 * https://wordpress.org/support/topic/php-8-2-error-6/#post-17472734
 		 */
-		$this->sidebars = array_filter( (array) $sidebars, function( $sidebar ) {
-			return isset( $sidebar['name'] );
-		} );
+		$this->sidebars = array_filter(
+			(array) $sidebars,
+			function( $sidebar ) {
+				return isset( $sidebar['name'] );
+			}
+		);
 
 		return $this->sidebars;
 

--- a/includes/class-genesis-simple-sidebars-core.php
+++ b/includes/class-genesis-simple-sidebars-core.php
@@ -15,7 +15,7 @@ class Genesis_Simple_Sidebars_Core {
 	/**
 	 * The created sidebars.
 	 *
-	 * @var string
+	 * @var array
 	 */
 	private $sidebars;
 
@@ -161,13 +161,20 @@ class Genesis_Simple_Sidebars_Core {
 	 */
 	public function get_sidebars( $cache = true ) {
 
-		if ( ! $cache ) {
-			return stripslashes_deep( get_option( Genesis_Simple_Sidebars()->settings_field ) );
+		if ( $cache && ! is_null( $this->sidebars ) ) {
+			return $this->sidebars;
 		}
 
-		if ( is_null( $this->sidebars ) ) {
-			$this->sidebars = stripslashes_deep( get_option( Genesis_Simple_Sidebars()->settings_field ) );
-		}
+		$sidebars = stripslashes_deep( get_option( Genesis_Simple_Sidebars()->settings_field ) );
+
+		/**
+		 * Sidebars without a name are invalid. Filtering these prevents
+		 * corrupted sidebar data from throwing errors, as seen in:
+		 * https://wordpress.org/support/topic/php-8-2-error-6/#post-17472734
+		 */
+		$this->sidebars = array_filter( (array) $sidebars, function( $sidebar ) {
+			return isset( $sidebar['name'] );
+		} );
 
 		return $this->sidebars;
 


### PR DESCRIPTION
Fixes PHP fatal errors under PHP 8.2+ caused by corrupt sidebar data.

Works by filtering out sidebars without a name when sidebars are fetched in `get_sidebars()`. The name is a required field when entering new sidebars, so sidebars missing a name are likely corrupt.

It's not clear _how_ sidebar data is corrupted, but we have reports in the wild of corrupt data resulting in the fatal error, "Cannot access offset of type string on string" when trying to access $sidebar['name'], for sidebars without a name property. See https://wordpress.org/support/topic/php-8-2-error-6/.

### To reproduce the error from the forum thread above

With the current `develop` branch and Simple Sidebars activated:

1. Set up a new WP site with PHP 8.2+ in Local and configure logging in `wp-config.php`:
    ```php
    if ( ! defined( 'WP_DEBUG' ) ) {
    	define( 'WP_DEBUG', true );
    }

    if ( ! defined( 'WP_DEBUG_LOG' ) ) {
    	define( 'WP_DEBUG_LOG', true );
    }
    ```

2. Open a site shell and update `ss-options` to contain the corrupt sidebar data from the user's post above:
    ```sh
     wp option update ss-settings '{"0": "__return_empty_array", "individual-teacher": {"name": "Individual Teacher", "description": ""}}' --format=json --skip-plugins
    ```

3. In the same shell, watch log output:
    ```sh
    echo '' > wp-content/debug.log && tail -f wp-content/debug.log
    ```

4. Visit a page that loads Genesis Simple Sidebars, such as the About Us page.

The page will fail to load.

Your watched log should show:

```
[05-Mar-2024 16:23:16 UTC] PHP Fatal error:  Uncaught TypeError: Cannot access offset of type string on string in /Users/user.name/Local Sites/php82/app/public/wp-content/plugins/genesis-simple-sidebars/includes/views/entry-metabox-content.php:35
Stack trace:
#0 /Users/user.name/Local Sites/php82/app/public/wp-content/plugins/genesis-simple-sidebars/includes/class-genesis-simple-sidebars-entry.php(46): require_once()
#1 /Users/user.name/Local Sites/php82/app/public/wp-admin/includes/template.php(1456): Genesis_Simple_Sidebars_Entry->metabox_content(Object(WP_Post), Array)
#2 /Users/user.name/Local Sites/php82/app/public/wp-admin/includes/post.php(2368): do_meta_boxes(Object(WP_Screen), 'side', Object(WP_Post))
#3 /Users/user.name/Local Sites/php82/app/public/wp-admin/edit-form-blocks.php(316): the_block_editor_meta_boxes()
#4 /Users/user.name/Local Sites/php82/app/public/wp-admin/post.php(187): require('/Users/user.nam...')
```

(It will also show 'Creation of dynamic property Genesis_Simple_Sidebars::$term is deprecated', which I'll fix in another PR.)

### How to test

1. Check out this branch: `git checkout nc/GF-3978/fix-corrupt-sidebars-causing-errors`
2. Visit the same "about us" page.

- [ ] The page should load.
- [ ]  There should be no more logged fatal error.
- [ ]  You should see one extra sidebar (other than Primary) in the Genesis Simple Sidebars area:
- [ ] Other Simple Sidebars functionality should not be affected.

<img width="1525" alt="genesis-simple-sidebars-working" src="https://github.com/studiopress/genesis-simple-sidebars/assets/647669/2e3202b0-d79b-4119-95b5-c19be8923a93">

### Documentation

No documentation required.
