### PR TITLE
[NOJIRA] Fix "dynamic property Genesis_Simple_Sidebars::$term" deprecation warning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ commands:
     description: "Add changes to SVN"
     steps:
       - run:
-          command: if [[ ! -z $(svn st | grep ^\!) ]]; then svn st | grep ^! | awk '{print " --force "$2}' | xargs -0r svn rm
+          command: if [[ ! -z $(svn st | grep ^\!) ]]; then svn st | grep ^! | awk '{print " --force "$2}' | xargs -0r svn rm; fi
       - run: svn add --force .
 
   svn_create_tag:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ commands:
   svn_add_changes:
     description: "Add changes to SVN"
     steps:
-      - run: svn st | grep ^! | awk '{print " --force "$2}' | xargs svn rm &>/dev/null
+      - run: svn st | grep ^! | awk '{print " --force "$2}' | xargs svn rm
       - run: svn add --force .
 
   svn_create_tag:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,8 @@ commands:
   svn_add_changes:
     description: "Add changes to SVN"
     steps:
-      - run: svn st | grep ^! | awk '{print " --force "$2}' | xargs -0r svn rm
+      - run:
+          command: if [[ ! -z $(svn st | grep ^\!) ]]; then svn st | grep ^! | awk '{print " --force "$2}' | xargs -0r svn rm
       - run: svn add --force .
 
   svn_create_tag:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ commands:
       - run: echo "export SLUG=$(grep '@package' /tmp/src/plugin.php | awk -F ' ' '{print $3}' | sed 's/^\s//')" >> ${BASH_ENV}
       - run: svn co https://plugins.svn.wordpress.org/${SLUG} --depth=empty .
       - run: svn up trunk
+      - run: svn up tags --depth=empty
       - run: find ./trunk -not -path "./trunk" -delete
       - run: cp -r /tmp/src/. ./trunk
       - run: svn propset svn:ignore -F ./trunk/.svnignore ./trunk
@@ -47,7 +48,6 @@ commands:
     description: "Create a SVN tag"
     steps:
       - set_verision_variable
-      - run: svn up tags --depth=empty
       - run: svn cp trunk tags/${VERSION}
 
   svn_commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ commands:
   svn_add_changes:
     description: "Add changes to SVN"
     steps:
-      - run: svn st | grep ^! | awk '{print " --force "$2}' | xargs svn rm
+      - run: svn st | grep ^! | awk '{print " --force "$2}' | xargs -0r svn rm
       - run: svn add --force .
 
   svn_create_tag:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,8 +103,8 @@ jobs:
       - attach_workspace:
           at: /tmp
       - svn_setup
-      - svn_add_changes
       - svn_create_tag
+      - svn_add_changes
       - svn_commit
 
 workflows:

--- a/includes/class-genesis-simple-sidebars.php
+++ b/includes/class-genesis-simple-sidebars.php
@@ -59,6 +59,14 @@ class Genesis_Simple_Sidebars {
 	 */
 	public $entry;
 
+
+	/**
+	 * Term.
+	 *
+	 * @var Genesis_Simple_Sidebars_Term
+	 */
+	public $term;
+
 	/**
 	 * Constructor.
 	 *


### PR DESCRIPTION
Fixes a PHP deprecation error under PHP 8.2+ caused by attempting to access a class property that was not defined.

### To reproduce the error

With the current `develop` branch and Simple Sidebars activated:

1. Set up a new WP site with PHP 8.2+ in Local and configure logging in `wp-config.php`:
    ```php
    if ( ! defined( 'WP_DEBUG' ) ) {
    	define( 'WP_DEBUG', true );
    }

    if ( ! defined( 'WP_DEBUG_LOG' ) ) {
    	define( 'WP_DEBUG_LOG', true );
    }
    ```

2. Open a site shell and watch debug output:
    ```sh
    echo '' > wp-content/debug.log && tail -f wp-content/debug.log
    ```

3. Visit the admin Dashboard page.

You'll see this deprecation warning in logs:

```
[05-Mar-2024 16:48:00 UTC] PHP Deprecated:  Creation of dynamic property Genesis_Simple_Sidebars::$term is deprecated in /Users/user.name/Local Sites/php82/app/public/wp-content/plugins/genesis-simple-sidebars/includes/class-genesis-simple-sidebars.php on line 162
```

### How to test

1. Check out this branch: `git checkout nc/fix-dynamic-property-deprecation-warning`
2. Visit the admin Dashboard page, which should load without further deprecation warnings.
(It can be easier to Ctrl+C in your site shell and re-run `echo '' > wp-content/debug.log && tail -f wp-content/debug.log` for a blank log file.)

### Documentation

No documentation required.
