### PR TITLE
[NOJIRA] Fix 'dynamic property Genesis_Simple_Sidebars::$term" deprecation warning under PHP 8.2+

### DIFF
--- a/includes/class-genesis-simple-sidebars.php
+++ b/includes/class-genesis-simple-sidebars.php
@@ -59,6 +59,14 @@ class Genesis_Simple_Sidebars {
 	 */
 	public $entry;
 
+
+	/**
+	 * Term.
+	 *
+	 * @var Genesis_Simple_Sidebars_Term
+	 */
+	public $term;
+
 	/**
 	 * Constructor.
 	 *


### PR DESCRIPTION
Fixes a PHP deprecation error under PHP 8.2+ caused by attempting to access a class property that was not defined.

### To reproduce the error

With the current `develop` branch and Simple Sidebars activated:

1. Set up a new WP site with PHP 8.2+ in Local and configure logging in `wp-config.php`:
    ```php
    if ( ! defined( 'WP_DEBUG' ) ) {
    	define( 'WP_DEBUG', true );
    }

    if ( ! defined( 'WP_DEBUG_LOG' ) ) {
    	define( 'WP_DEBUG_LOG', true );
    }
    ```

2. Open a site shell and watch debug output:
    ```sh
    echo '' > wp-content/debug.log && tail -f wp-content/debug.log
    ```

3. Visit the admin Dashboard page.

You'll see this deprecation warning in logs:

```
[05-Mar-2024 16:48:00 UTC] PHP Deprecated:  Creation of dynamic property Genesis_Simple_Sidebars::$term is deprecated in /Users/user.name/Local Sites/php82/app/public/wp-content/plugins/genesis-simple-sidebars/includes/class-genesis-simple-sidebars.php on line 162
```

### How to test

1. Check out this branch: `git checkout nc/fix-dynamic-property-deprecation-warning`
2. Visit the admin Dashboard page, which should load without further deprecation warnings.
(It can be easier to Ctrl+C in your site shell and re-run `echo '' > wp-content/debug.log && tail -f wp-content/debug.log` for a blank log file.)

### Documentation

No documentation required.
