### PR TITLE
[NOJIRA] Fix Genesis download link escaping

### DIFF
--- a/includes/class-genesis-simple-sidebars.php
+++ b/includes/class-genesis-simple-sidebars.php
@@ -100,7 +100,15 @@ class Genesis_Simple_Sidebars {
 
 			// translators: %1$s is WordPress minimum version, %2$s is Genesis minimum version, %3$s is action and %4$s is link.
 			$message = sprintf( __( 'Genesis Simple Sidebars requires WordPress %1$s and Genesis %2$s, or greater. Please %3$s the latest version of <a href="%4$s" target="_blank">Genesis</a> to use this plugin.', 'genesis-simple-sidebars' ), $this->min_wp_version, $this->min_genesis_version, $action, 'http://my.studiopress.com/?download_id=91046d629e74d525b3f2978e404e7ffa' );
-			echo '<div class="notice notice-warning"><p>' . esc_html( $message ) . '</p></div>';
+
+			$allowed_html = array(
+				'a' => array(
+					'href'   => array(),
+					'target' => array(),
+				),
+			);
+
+			echo '<div class="notice notice-warning"><p>' . wp_kses( $message, $allowed_html ) . '</p></div>';
 
 		}
 


### PR DESCRIPTION
When Genesis is not installed and activated, we display a prompt to do so, but the download link is currently broken:

<img width="1151" alt="Screenshot 2024-03-05 at 18 02 40" src="https://github.com/studiopress/genesis-simple-sidebars/assets/647669/612fa0b3-1689-41ee-98fe-b0ab320d1a17">

This PR makes the escaped link clickable instead of plain text:

<img width="1007" alt="Screenshot 2024-03-05 at 18 02 19" src="https://github.com/studiopress/genesis-simple-sidebars/assets/647669/15ea021f-9739-4c7b-89e6-907992a7a134">

---

Replaces #39, which was good apart from a variable name (`allowed_HTML`) and allowing 'title' in the anchor's properties instead of 'target'.

### To reproduce the raw HTML issue
On the develop branch, activate Genesis Simple Sidebars and the Twenty Twenty-Four theme.

### How to test
1. Check out this branch.
2. You should see the Genesis download link instead of the HTML anchor tag.

### Documentation
No documentation required.
