### PR TITLE
[NOJIRA] Prepare for release of 2.2.3

### DIFF
--- a/genesis-simple-sidebars.php
+++ b/genesis-simple-sidebars.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'GENESIS_SIMPLE_SIDEBARS_SETTINGS_FIELD', 'genesis_simple_sidebars_settings' );
-define( 'GENESIS_SIMPLE_SIDEBARS_VERSION', '2.2.2' );
+define( 'GENESIS_SIMPLE_SIDEBARS_VERSION', '2.2.3' );
 define( 'GENESIS_SIMPLE_SIDEBARS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'GENESIS_SIMPLE_SIDEBARS_PLUGIN_URL', plugins_url( '', __FILE__ ) );
 

--- a/languages/genesis-simple-sidebars.pot
+++ b/languages/genesis-simple-sidebars.pot
@@ -1,14 +1,14 @@
-# Copyright (C) 2019 StudioPress
+# Copyright (C) 2024 StudioPress
 # This file is distributed under the GNU General Public License v2.0 (or later).
 msgid ""
 msgstr ""
-"Project-Id-Version: Genesis Simple Sidebars 2.2.1\n"
+"Project-Id-Version: Genesis Simple Sidebars 2.2.3\n"
 "Report-Msgid-Bugs-To: StudioPress <translations@studiopress.com>\n"
-"POT-Creation-Date: 2019-07-05 14:42:22+00:00\n"
+"POT-Creation-Date: 2024-03-06 09:04:30+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2019-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2024-MO-DA HO:MI+ZONE\n"
 "Last-Translator: StudioPress <translations@studiopress.com>\n"
 "Language-Team: English <translations@studiopress.com>\n"
 "X-Generator: grunt-wp-i18n 0.4.4\n"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "description": "Genesis Simple Sidebars allows you to easily create and use new sidebar widget areas.",
     "author": "StudioPress",
     "authoruri": "http://www.studiopress.com/",
-    "version": "2.2.2",
+    "version": "2.2.3",
     "license": "GPL-2.0+",
     "licenseuri": "http://www.gnu.org/licenses/gpl-2.0.html",
     "textdomain": "genesis-simple-sidebars"

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
     "type": "git",
     "url": "https://github.com/copyblogger/genesis-simple-sidebars"
   },
-  "dependencies": {},
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-autoprefixer": "^0.8.1",
     "grunt-checktextdomain": "^0.1.1",
+    "grunt-cli": "^1.4.3",
     "grunt-contrib-cssmin": "^0.10.0",
     "grunt-contrib-imagemin": "^0.7.1",
     "grunt-contrib-jshint": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "grunt-jsvalidate": "^0.2.2",
     "grunt-phplint": "0.0.5",
     "grunt-styledocco": "^0.1.4",
-    "grunt-wp-i18n": "^0.4.7",
+    "grunt-wp-i18n": "^1.0.3",
     "load-grunt-tasks": "^0.6.0"
   },
   "plugin": {

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Genesis Simple Sidebars
  * Plugin URI: https://github.com/studiopress/genesis-simple-sidebars
  * Description: Genesis Simple Sidebars allows you to easily create and use new sidebar widget areas.
- * Version: 2.2.2
+ * Version: 2.2.3
  * Author: StudioPress
  * Author URI: https://www.studiopress.com/
  * License: GNU General Public License v2.0 (or later)

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_i
 Tags: hooks, genesis, genesiswp, studiopress
 Requires at least: 4.7.3
 Tested up to: 6.3
-Stable tag: 2.2.2
+Stable tag: 2.2.3
 
 This plugin allows you to create multiple, dynamic widget areas, and assign those widget areas to sidebar locations within the Genesis Framework on a per post, per page, or per tag/category archive basis.
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: nathanrice, wpmuguru, marksabbath
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=5553118
 Tags: hooks, genesis, genesiswp, studiopress
 Requires at least: 4.7.3
-Tested up to: 6.3
+Tested up to: 6.4
 Stable tag: 2.2.3
 
 This plugin allows you to create multiple, dynamic widget areas, and assign those widget areas to sidebar locations within the Genesis Framework on a per post, per page, or per tag/category archive basis.

--- a/readme.txt
+++ b/readme.txt
@@ -37,6 +37,10 @@ Not in the way you're probably thinking. The markup surrounding the widget area 
 
 == Changelog ==
 
+= 2.2.3 =
+* Prevent a PHP fatal error under PHP 8.x if incomplete sidebar data exists.
+* Fix a PHP deprecation warning under PHP 8.x.
+* Fix Genesis download link in admin notice if a Genesis child theme is not active.
 
 = 2.2.2 =
 * Fix overlapping of sidebar selector in editor.


### PR DESCRIPTION
- Bumps version to 2.2.3. ([Current version](https://wordpress.org/plugins/genesis-simple-sidebars/) is 2.2.2, this update just has bug fixes.)
- Updates changelog.
- Makes `grunt-cli` a devDependency to allow us to run `npm i && npx grunt makepot`, without having to install grunt globally.
- Updates grunt makepot dependency so it doesn't fail to build pot files under PHP 8 (the old version used `create_function()`, which PHP removed in 8.0).
- Increments 'tested up to' for WP 6.4. 

@dreamwhisper @kienstra Would love your help with the release process, if you have time. I haven't released a plugin since you switched to Circle-based deploys. ❤️ 