### PR TITLE
Fix `svn` deployment by using `wp-svn` orb 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,11 @@ workflows:
           requires:
             - approval-for-deploy-tested-up-to-bump
       - wp-svn/deploy:
-          dry-run: true
+          context: genesis-svn
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/
           requires:
             - checks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,63 +1,7 @@
 version: 2.1
 
 orbs:
-  wp-svn: studiopress/wp-svn@0.1
-
-commands:
-  install_dependencies:
-    description: "Install development dependencies."
-    steps:
-      - run: composer install
-
-  mkdir_artifacts:
-    description: "Make Artifacts directory"
-    steps:
-      - run:
-          command: |
-            [ ! -d "/tmp/artifacts" ] && mkdir /tmp/artifacts &>/dev/null
-
-  set_verision_variable:
-    description: "Set the VERSION environment variable"
-    steps:
-      - run:
-          command: |
-            echo "export VERSION=$(grep 'Version:' /tmp/src/plugin.php | awk -F: '{print $2}' | sed 's/^\s//')" >> ${BASH_ENV}
-
-  show_pwd_info:
-    description: "Show information about the current directory"
-    steps:
-      - run: pwd
-      - run: ls -lash
-
-  svn_setup:
-    description: "Setup SVN"
-    steps:
-      - run: echo "export SLUG=$(grep '@package' /tmp/src/plugin.php | awk -F ' ' '{print $3}' | sed 's/^\s//')" >> ${BASH_ENV}
-      - run: svn co https://plugins.svn.wordpress.org/${SLUG} --depth=empty .
-      - run: svn up trunk
-      - run: svn up tags --depth=empty
-      - run: find ./trunk -not -path "./trunk" -delete
-      - run: cp -r /tmp/src/. ./trunk
-      - run: svn propset svn:ignore -F ./trunk/.svnignore ./trunk
-
-  svn_add_changes:
-    description: "Add changes to SVN"
-    steps:
-      - run:
-          command: if [[ ! -z $(svn st | grep ^\!) ]]; then svn st | grep ^! | awk '{print " --force "$2}' | xargs -0r svn rm; fi
-      - run: svn add --force .
-
-  svn_create_tag:
-    description: "Create a SVN tag"
-    steps:
-      - set_verision_variable
-      - run: svn cp trunk tags/${VERSION}
-
-  svn_commit:
-    description: "Commit changes to SVN"
-    steps:
-      - set_verision_variable
-      - run: svn ci -m "Tagging ${VERSION} from Github" --no-auth-cache --non-interactive --username "${SVN_USERNAME}" --password "${SVN_PASSWORD}"
+  wp-svn: studiopress/wp-svn@0.2
 
 executors:
   base:
@@ -70,63 +14,18 @@ executors:
     working_directory: /tmp/src
 
 jobs:
-  checkout:
-    executor: base
-    steps:
-      - mkdir_artifacts
-      - checkout:
-          path: src
-      - persist_to_workspace:
-          root: /tmp
-          paths:
-            - src
-
   checks:
     executor: php_node
     steps:
-      - attach_workspace:
-          at: /tmp
-      - install_dependencies
-      - run: composer phpcs
-
-  deploy_svn_branch:
-    executor: base
-    working_directory: /tmp/artifacts
-    steps:
-      - attach_workspace:
-          at: /tmp
-      - svn_setup
-      - svn_add_changes
-      - svn_commit
-
-  deploy_svn_tag:
-    executor: base
-    working_directory: /tmp/artifacts
-    steps:
-      - attach_workspace:
-          at: /tmp
-      - svn_setup
-      - svn_create_tag
-      - svn_add_changes
-      - svn_commit
+      - checkout
+      - run: composer install && composer phpcs
 
 workflows:
   test-deploy:
     jobs:
-      - checkout:
-          filters:
-            branches:
-              ignore:
-                - master
-      - checks:
-          requires:
-            - checkout
-          filters:
-            branches:
-              ignore:
-                - master
+      - checks
       - approval-for-deploy-tested-up-to-bump:
-          requires: 
+          requires:
             - checks
           type: approval
           filters:
@@ -138,52 +37,7 @@ workflows:
           context: genesis-svn
           requires:
             - approval-for-deploy-tested-up-to-bump
-
-  branch_deploy:
-    jobs:
-      - checkout:
-          filters:
-            branches:
-              only:
-                - master
-      - checks:
-          requires:
-            - checkout
-          filters:
-            branches:
-              only:
-                - master
-      - deploy_svn_branch:
-          context: genesis-svn
+      - wp-svn/deploy:
+          dry-run: true
           requires:
             - checks
-          filters:
-            branches:
-              only:
-                - master
-
-  tag_deploy:
-    jobs:
-      - checkout:
-          filters:
-            tags:
-              only: /^\d+\.\d+\.\d+$/
-            branches:
-              ignore: /.*/
-      - checks:
-          requires:
-            - checkout
-          filters:
-            tags:
-              only: /^\d+\.\d+\.\d+$/
-            branches:
-              ignore: /.*/
-      - deploy_svn_tag:
-          context: genesis-svn
-          requires:
-            - checks
-          filters:
-            tags:
-              only: /^\d+\.\d+\.\d+$/
-            branches:
-              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,14 +4,9 @@ orbs:
   wp-svn: studiopress/wp-svn@0.2
 
 executors:
-  base:
-    docker:
-      - image: cimg/base:current
-    working_directory: /tmp
   php_node:
     docker:
       - image: cimg/php:7.3-node
-    working_directory: /tmp/src
 
 jobs:
   checks:


### PR DESCRIPTION
<!-- A short but detailed summary of the changes. -->

Uses our [wp-svn Orb](https://circleci.com/developer/orbs/orb/studiopress/wp-svn), like [Genesis Connect Woocommerce does](https://github.com/studiopress/genesis-connect-woocommerce/blob/develop/.circleci/config.yml#L40C9-L48)

### How to test
<!-- Detailed steps to test this PR. -->
* Look at the `svn stat` [from the dry run](https://app.circleci.com/pipelines/github/studiopress/genesis-simple-sidebars/124/workflows/759e2d4b-4dbd-4e1d-9bc1-8a47594538d3/jobs/278)

### Next steps
After this is merged, Nick publishes a new `2.2.3` release, and we'll see if this deployed to production correctly

### Documentation
No documentation required. 

