### PR TITLE
Trivial changes to maybe trigger CI/CD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,16 +9,16 @@ executors:
       - image: cimg/php:7.3-node
 
 jobs:
-  checks:
+  lint:
     executor: php_node
     steps:
       - checkout
       - run: composer install && composer phpcs
 
 workflows:
-  test-deploy:
+  lint-deploy:
     jobs:
-      - checks
+      - lint
       - approval-for-deploy-tested-up-to-bump:
           requires:
             - checks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,10 @@ version: 2.1
 orbs:
   wp-svn: studiopress/wp-svn@0.2
 
-executors:
-  php_node:
-    docker:
-      - image: cimg/php:7.3-node
-
 jobs:
   lint:
-    executor: php_node
+    docker:
+      - image: cimg/php:7.3-node
     steps:
       - checkout
       - run: composer install && composer phpcs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ workflows:
       - lint
       - approval-for-deploy-tested-up-to-bump:
           requires:
-            - checks
+            - lint
           type: approval
           filters:
             tags:
@@ -40,4 +40,4 @@ workflows:
             branches:
               ignore: /.*/
           requires:
-            - checks
+            - lint


### PR DESCRIPTION
CI/CD didn't run on the latest `2.2.3` tag.

Let's see if this change, and publishing a new `2.2.3` release, make it run.

### Next step

After merging, Nick publishes another `2.2.3` release

### How to test
<!-- Detailed steps to test this PR. -->
Not needed

