### PR TITLE
[Don't merge] Hack to force deploy 2.2.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,10 +30,5 @@ workflows:
             - approval-for-deploy-tested-up-to-bump
       - wp-svn/deploy:
           context: genesis-svn
-          filters:
-            tags:
-              only: /^\d+\.\d+\.\d+$/
-            branches:
-              ignore: /.*/
           requires:
             - lint


### PR DESCRIPTION
Don't merge this! 

It's a hack, because re-publishing the `2.2.3` tag didn't trigger a CI/CD workflow
