### PR TITLE
Defer textdomain loading and admin menu registration to fix early translation notice

### DIFF
--- a/includes/class-genesis-simple-sidebars-admin.php
+++ b/includes/class-genesis-simple-sidebars-admin.php
@@ -51,8 +51,18 @@ class Genesis_Simple_Sidebars_Admin extends Genesis_Admin_Basic {
 		$menu_ops = array(
 			'submenu' => array(
 				'parent_slug' => 'genesis',
-				'page_title'  => __( 'Genesis - Simple Sidebars', 'genesis-simple-sidebars' ),
-				'menu_title'  => __( 'Simple Sidebars', 'genesis-simple-sidebars' ),
+
+				/*
+				* These strings intentionally avoid using the plugin text
+				* domain here because this method can be called before the
+				* `init` action (via `genesis_setup`). Using `__()` with the
+				* `genesis-simple-sidebars` domain at that point would cause
+				* WordPress 6.7+ to emit a "_load_textdomain_just_in_time
+				* was called incorrectly" notice. Other plugin strings remain
+				* fully translatable once the text domain is loaded on `init`.
+				*/
+				'page_title'  => 'Genesis - Simple Sidebars',
+				'menu_title'  => 'Simple Sidebars',
 			),
 		);
 

--- a/includes/class-genesis-simple-sidebars.php
+++ b/includes/class-genesis-simple-sidebars.php
@@ -86,7 +86,7 @@ class Genesis_Simple_Sidebars {
 	 */
 	public function init() {
 
-		$this->load_plugin_textdomain();
+		add_action( 'init', array( $this, 'load_plugin_textdomain' ) );
 
 		add_action( 'admin_notices', array( $this, 'requirements_notice' ) );
 


### PR DESCRIPTION
## Summary

- Fixes WP 6.7+ notice about early translation loading for genesis-simple-sidebars.
- Loads the plugin textdomain on init and registers the admin page on admin_menu to ensure translations are used only after the textdomain is available.

### How to test
1. Enable Xdebug in the selected Local Site 
2. Activate the plugin and visit ```wp-admin > Plugins```.
3. Confirm no “_load_textdomain_just_in_time was called incorrectly” notice in ```debug.log```.
4. Visit ```Genesis > Simple Sidebars``` and verify menu and page strings still translate.

