### PR TITLE
Update “Tested up to” from 6.4 to 6.9

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: nathanrice, wpmuguru, marksabbath
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=5553118
 Tags: hooks, genesis, genesiswp, studiopress
 Requires at least: 4.7.3
-Tested up to: 6.4
+Tested up to: 6.9
 Stable tag: 2.2.3
 
 This plugin allows you to create multiple, dynamic widget areas, and assign those widget areas to sidebar locations within the Genesis Framework on a per post, per page, or per tag/category archive basis.


### PR DESCRIPTION
### Summary

Bumps the WordPress compatibility in readme.txt to “Tested up to: 6.9” to reflect validation against WP 6.9.