### PR TITLE
chore: mark as tested with WP 7.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: nathanrice, wpmuguru, marksabbath
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=5553118
 Tags: hooks, genesis, genesiswp, studiopress
 Requires at least: 4.7.3
-Tested up to: 6.9
+Tested up to: 7.0
 Stable tag: 2.2.3
 
 This plugin allows you to create multiple, dynamic widget areas, and assign those widget areas to sidebar locations within the Genesis Framework on a per post, per page, or per tag/category archive basis.


### PR DESCRIPTION
Bumps 'tested up to' to 7.0.